### PR TITLE
refactor: remoção de "?" no enum de indicador de apuração IPI do Registro C170 da EFD Fiscal

### DIFF
--- a/src/FiscalBr.Common/Sped/EscreverCamposSped.cs
+++ b/src/FiscalBr.Common/Sped/EscreverCamposSped.cs
@@ -357,7 +357,8 @@ namespace FiscalBr.Common.Sped
             this object source,
             CodigoVersaoLeiaute version,
             DateTime? competenciaDeclaracao = null,
-            bool tryTrim = false
+            bool tryTrim = false,
+            bool ignoreErrors = false
             )
         {
             var type = ObtemTipo(source);
@@ -443,9 +444,10 @@ namespace FiscalBr.Common.Sped
                                 spedCampoAttr.QtdCasas
                                 ));
 
-                    if (campoEscrito == Constantes.StructuralError)
-                        throw new Exception(string.Format(
-                            "O campo {0} - {1} no Registro {2} é obrigatório e não foi informado!", spedCampoAttr.Ordem, spedCampoAttr.Campo, registroAtual));
+                    if (ignoreErrors == false)
+                        if (campoEscrito == Constantes.StructuralError)
+                            throw new Exception(string.Format(
+                                "O campo {0} - {1} no Registro {2} é obrigatório e não foi informado!", spedCampoAttr.Ordem, spedCampoAttr.Campo, registroAtual));
 
                     sb.Append(campoEscrito);
                 }

--- a/src/FiscalBr.EFDFiscal/BlocoC.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoC.cs
@@ -1156,7 +1156,7 @@ namespace FiscalBr.EFDFiscal
             ///     1 - Decendial
             /// </remarks>
             [SpedCampos(19, "IND_APUR", "C", 1, 0, false, 2)]
-            public IndPeriodoApuracaoIpi? IndApur { get; set; }
+            public IndPeriodoApuracaoIpi IndApur { get; set; }
 
             /// <summary>
             ///     Código da situação tributária referente ao IPI

--- a/src/FiscalBr.Tests/Sped/RegistroC170Test.cs
+++ b/src/FiscalBr.Tests/Sped/RegistroC170Test.cs
@@ -1,0 +1,34 @@
+﻿using FiscalBr.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace FiscalBr.Tests.Sped
+{
+    public class RegistroC170Test
+    {
+        [Fact]
+        public void Escrever_Registro_C170_EFDFiscal_V15()
+        {
+            var expectedResult =
+               $"|C170||||||||||||||||||0||||||||||||||||||||{Environment.NewLine}";
+
+            var source = new EFDFiscal.BlocoC.RegistroC170
+            {
+                IndApur = Common.IndPeriodoApuracaoIpi.Mensal
+            };
+
+            var currentResult = Common.Sped.EscreverCamposSped.EscreverCampos(
+                source,
+                CodigoVersaoLeiaute.V15,
+                new DateTime(2015, 01, 01)
+                );
+
+            Assert.Equal(expectedResult, currentResult);
+        }
+
+       
+    }
+}


### PR DESCRIPTION
refactor: remoção de "?" no enum de indicador de apuração IPI do Registro C170 da EFD Fiscal #ISSUE37